### PR TITLE
change fasthttp.RequestHandler to func(ctx *fasthttp.RequestCtx)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+vendor/
+.idea/
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out

--- a/utils.go
+++ b/utils.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Upgrade returns a RequestHandler for fasthttp resuming upgrading process.
-func Upgrade(handler RequestHandler) fasthttp.RequestHandler {
+func Upgrade(handler RequestHandler) func(ctx *fasthttp.RequestCtx) {
 	upgr := Upgrader{
 		Handler:  handler,
 		Compress: true,


### PR DESCRIPTION
change fasthttp.RequestHandler to func(ctx *fasthttp.RequestCtx)  to support another fasthttp router , not only fasthttp/router