### PR TITLE
Recognize upgrade response by using second upgrade string.

### DIFF
--- a/client.go
+++ b/client.go
@@ -66,8 +66,10 @@ func client(c net.Conn, url string, r *fasthttp.Request) (conn *Conn, err error)
 	bw.Flush()
 	err = res.Read(br)
 	if err == nil {
+		upgradeValue := res.Header.PeekBytes(upgradeString)
 		if res.StatusCode() != 101 ||
-			!bytes.Equal(res.Header.PeekBytes(upgradeString), websocketString) {
+			(!bytes.Equal(upgradeValue, websocketString) &&
+			 !bytes.Equal(upgradeValue, websocket2String)) {
 			err = ErrCannotUpgrade
 		} else {
 			conn = acquireConn(c)

--- a/strings.go
+++ b/strings.go
@@ -7,6 +7,7 @@ var (
 	connectionString    = []byte("Connection")
 	upgradeString       = []byte("Upgrade")
 	websocketString     = []byte("WebSocket")
+	websocket2String    = []byte("websocket")
 	commaString         = []byte(",")
 	wsHeaderVersion     = []byte("Sec-WebSocket-Version")
 	wsHeaderKey         = []byte("Sec-WebSocket-Key")


### PR DESCRIPTION
This fix for some websocket servers which sends 'upgrade' with 'websocket' text instead 'WebSocket'.